### PR TITLE
Add Front Door Ruleset for handling complete ruby>.NET rerouting

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,10 +33,12 @@ This project creates and manages the RSD FrontDoor CDN.
 | [azurerm_cdn_frontdoor_profile.rsd](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/cdn_frontdoor_profile) | resource |
 | [azurerm_cdn_frontdoor_route.rsd](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/cdn_frontdoor_route) | resource |
 | [azurerm_cdn_frontdoor_rule.add_response_headers](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/cdn_frontdoor_rule) | resource |
+| [azurerm_cdn_frontdoor_rule.complete_dotnet_ruby_migration](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/cdn_frontdoor_rule) | resource |
 | [azurerm_cdn_frontdoor_rule.remove_response_headers](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/cdn_frontdoor_rule) | resource |
 | [azurerm_cdn_frontdoor_rule.security](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/cdn_frontdoor_rule) | resource |
 | [azurerm_cdn_frontdoor_rule.vdp_security_txt](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/cdn_frontdoor_rule) | resource |
 | [azurerm_cdn_frontdoor_rule.vdp_thanks_txt](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/cdn_frontdoor_rule) | resource |
+| [azurerm_cdn_frontdoor_rule_set.complete_dotnet_ruby_migration](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/cdn_frontdoor_rule_set) | resource |
 | [azurerm_cdn_frontdoor_rule_set.response_headers](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/cdn_frontdoor_rule_set) | resource |
 | [azurerm_cdn_frontdoor_rule_set.security](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/cdn_frontdoor_rule_set) | resource |
 | [azurerm_cdn_frontdoor_rule_set.vdp](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/cdn_frontdoor_rule_set) | resource |
@@ -56,6 +58,7 @@ This project creates and manages the RSD FrontDoor CDN.
 | <a name="input_azure_location"></a> [azure\_location](#input\_azure\_location) | Azure location in which to launch resources. | `string` | n/a | yes |
 | <a name="input_azure_subscription_id"></a> [azure\_subscription\_id](#input\_azure\_subscription\_id) | Service Principal Subscription ID | `string` | n/a | yes |
 | <a name="input_azure_tenant_id"></a> [azure\_tenant\_id](#input\_azure\_tenant\_id) | Service Principal Tenant ID | `string` | n/a | yes |
+| <a name="input_enable_custom_reroute_ruleset"></a> [enable\_custom\_reroute\_ruleset](#input\_enable\_custom\_reroute\_ruleset) | Toggle on/off the re-routing of traffic accessing the Ruby Complete app under certain request paths which should route to the .NET Complete app backend origin | `bool` | `false` | no |
 | <a name="input_enable_frontdoor"></a> [enable\_frontdoor](#input\_enable\_frontdoor) | Launch the FrontDoor CDN | `bool` | `false` | no |
 | <a name="input_enable_frontdoor_vdp_redirects"></a> [enable\_frontdoor\_vdp\_redirects](#input\_enable\_frontdoor\_vdp\_redirects) | Creates a redirect rule set for security.txt and thanks.txt to an external Vulnerability Disclosure Program service | `bool` | `true` | no |
 | <a name="input_enable_frontdoor_waf"></a> [enable\_frontdoor\_waf](#input\_enable\_frontdoor\_waf) | Enable or Disable the Front Door WAF Policy | `bool` | `true` | no |

--- a/frontdoor.tf
+++ b/frontdoor.tf
@@ -97,7 +97,8 @@ resource "azurerm_cdn_frontdoor_route" "rsd" {
   cdn_frontdoor_rule_set_ids = compact([
     local.enable_frontdoor_vdp_redirects ? azurerm_cdn_frontdoor_rule_set.vdp[0].id : null,
     each.value.enable_security_headers ? azurerm_cdn_frontdoor_rule_set.security[0].id : null,
-    length(each.value.add_http_response_headers) > 0 || length(each.value.remove_http_response_headers) > 0 ? azurerm_cdn_frontdoor_rule_set.response_headers[each.key].id : null
+    length(each.value.add_http_response_headers) > 0 || length(each.value.remove_http_response_headers) > 0 ? azurerm_cdn_frontdoor_rule_set.response_headers[each.key].id : null,
+    each.key == "complete-ruby" && local.enable_custom_reroute_ruleset ? azurerm_cdn_frontdoor_rule_set.complete_dotnet_ruby_migration[0].id : null,
   ])
   cdn_frontdoor_origin_ids = [
     azurerm_cdn_frontdoor_origin.rsd[each.key].id

--- a/locals.tf
+++ b/locals.tf
@@ -29,4 +29,5 @@ locals {
   waf_rate_limiting_duration_in_minutes = var.waf_rate_limiting_duration_in_minutes
   waf_rate_limiting_threshold           = var.waf_rate_limiting_threshold
   waf_rate_limiting_bypass_ip_list      = var.waf_rate_limiting_bypass_ip_list
+  enable_custom_reroute_ruleset         = var.enable_custom_reroute_ruleset
 }

--- a/variables.tf
+++ b/variables.tf
@@ -180,3 +180,9 @@ variable "waf_rate_limiting_bypass_ip_list" {
   type        = list(string)
   default     = []
 }
+
+variable "enable_custom_reroute_ruleset" {
+  description = "Toggle on/off the re-routing of traffic accessing the Ruby Complete app under certain request paths which should route to the .NET Complete app backend origin"
+  type        = bool
+  default     = false
+}


### PR DESCRIPTION
- creates a custom rule set only applied to the `complete-ruby` endpoint which allows us to programatically re-route inbound traffic that hits a certain path, towards the `complete-dotnet` origin