### PR TITLE
Split ruleset into multiple rules to avoid max 10 per rule limit

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -32,5 +32,27 @@ locals {
   waf_rate_limiting_duration_in_minutes = var.waf_rate_limiting_duration_in_minutes
   waf_rate_limiting_threshold           = var.waf_rate_limiting_threshold
   waf_rate_limiting_bypass_ip_list      = var.waf_rate_limiting_bypass_ip_list
-  enable_custom_reroute_ruleset         = var.enable_custom_reroute_ruleset
+
+
+  enable_custom_reroute_ruleset = var.enable_custom_reroute_ruleset
+  complete_dotnet_ruby_migration_paths = {
+    "assets" : [
+      "dist",
+      "signin-oidc",
+      "netassets",
+      "accessibility",
+      "search"
+    ],
+    "projects" : [
+      "projects/all/by-month",
+      "projects/all/completed",
+      "projects/all/in-progress",
+      "projects/all/local-authorities",
+      "projects/all/regions",
+      "projects/all/trusts",
+      "projects/all/users",
+      "projects/team",
+      "projects/yours",
+    ]
+  }
 }

--- a/rulesets.tf
+++ b/rulesets.tf
@@ -198,13 +198,13 @@ resource "azurerm_cdn_frontdoor_rule_set" "complete_dotnet_ruby_migration" {
 }
 
 resource "azurerm_cdn_frontdoor_rule" "complete_dotnet_ruby_migration" {
-  count = local.enable_frontdoor ? 1 : 0
+  for_each = local.enable_frontdoor ? local.complete_dotnet_ruby_migration_paths : {}
 
   depends_on = [azurerm_cdn_frontdoor_origin_group.rsd, azurerm_cdn_frontdoor_origin.rsd]
 
-  name                      = "rerouteorigin"
+  name                      = "rerouteorigin${each.key}"
   cdn_frontdoor_rule_set_id = azurerm_cdn_frontdoor_rule_set.complete_dotnet_ruby_migration[0].id
-  order                     = 1
+  order                     = index(keys(local.complete_dotnet_ruby_migration_paths), each.key) + 1
   behavior_on_match         = "Continue"
 
   actions {
@@ -223,23 +223,8 @@ resource "azurerm_cdn_frontdoor_rule" "complete_dotnet_ruby_migration" {
 
   conditions {
     url_path_condition {
-      match_values = [
-        "dist",
-        "signin-oidc",
-        "netassets",
-        "accessibility",
-        "projects/all/by-month",
-        "projects/all/completed",
-        "projects/all/in-progress",
-        "projects/all/local-authorities",
-        "projects/all/regions",
-        "projects/all/trusts",
-        "projects/all/users",
-        "projects/team",
-        "projects/yours",
-        "search"
-      ]
-      operator = "BeginsWith"
+      match_values = each.value
+      operator     = "BeginsWith"
     }
   }
 }


### PR DESCRIPTION
The .NET rewrite ruleset was previously all handled by a single rule, unfortunately there is a maximum number of 10 match value conditions that we can have in a single rule, so this change will split it up into a dynamic map of routes grouped by a contextual key. In this case we have 'assets' and 'projects'. The key isn't important, it's just tacked onto the end of the rule name. If adding new routes, ensure there is no more than 10 in a single group.