### PR TITLE
update frontdoor rules for test

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -69,9 +69,9 @@ locals {
         "cookies",
       ]
     },
-    "searchDEV" : {
+    "search" : {
       environment : [
-        "development",
+        "development", "test",
       ]
       require_cookie : false,
       routes : [
@@ -79,19 +79,9 @@ locals {
       ],
       operator : "RegEx"
     },
-    "searchTEST" : {
+    "projectsDEV" : {
       environment : [
-        "test",
-      ]
-      require_cookie : true,
-      routes : [
-        "^search(?:\\?(?:[^\\/#]*))?$",
-      ],
-      operator : "RegEx"
-    },
-    "projects" : {
-      environment : [
-        "development", "test",
+        "development",
       ]
       require_cookie : false,
       routes : [
@@ -104,6 +94,15 @@ locals {
         "projects/all/users",
         "projects/team",
         "projects/yours",
+      ]
+    },
+    "projectsTEST" : {
+      environment : [
+        "test",
+      ]
+      require_cookie : true,
+      routes : [
+        "projects/all/in-progress/all"
       ]
     }
   }


### PR DESCRIPTION
Rules for assets, search and the cookies anti-forgery (i.e. attach ruby origin for cookies POST) to all be enabled on the dev and test env.

Lock projects forwarding down to dev and bring a single route into test env, behind the bypass cookie