### PR TITLE
Deprecated: Removed minimum_tls_version

### DIFF
--- a/frontdoor.tf
+++ b/frontdoor.tf
@@ -74,7 +74,6 @@ resource "azurerm_cdn_frontdoor_custom_domain" "rsd" {
 
   tls {
     certificate_type    = "ManagedCertificate"
-    minimum_tls_version = "TLS12"
   }
 }
 


### PR DESCRIPTION
* This defaults to a single option of TLS12 supports no other options