### PR TITLE
Feat/dotnet release 1.8.0

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -100,6 +100,14 @@ locals {
       order : 40,
       require_cookie : false,
       routes : [
+        "projects/team",
+        "projects/yours",
+      ]
+    },
+    "all_projects" : {
+      order : 50,
+      require_cookie : false,
+      routes : [
         "projects/all/by-month",
         "projects/all/completed",
         "projects/all/in-progress",
@@ -107,8 +115,25 @@ locals {
         "projects/all/regions",
         "projects/all/trusts",
         "projects/all/users",
-        "projects/team",
-        "projects/yours",
+        "projects/all/statistics",
+      ]
+    },
+    "service_support" : {
+      order : 60,
+      require_cookie : false,
+      routes : [
+        "projects/service-support/with-academy-urn",
+        "projects/service-support/without-academy-urn",
+        "service-support/local-authorities",
+        "projects/all/local-authorities",
+      ]
+    },
+    "exports" : {
+      order : 70,
+      require_cookie : false,
+      routes : [
+        "projects/all/export",
+        "projects/all/reports",
       ]
     }
   }
@@ -153,6 +178,14 @@ locals {
       order : 40,
       require_cookie : false,
       routes : [
+        "projects/team",
+        "projects/yours",
+      ]
+    },
+    "all_projects" : {
+      order : 50,
+      require_cookie : false,
+      routes : [
         "projects/all/by-month",
         "projects/all/completed",
         "projects/all/in-progress",
@@ -160,8 +193,25 @@ locals {
         "projects/all/regions",
         "projects/all/trusts",
         "projects/all/users",
-        "projects/team",
-        "projects/yours",
+        "projects/all/statistics",
+      ]
+    },
+    "service_support" : {
+      order : 60,
+      require_cookie : true,
+      routes : [
+        "projects/service-support/with-academy-urn",
+        "projects/service-support/without-academy-urn",
+        "service-support/local-authorities",
+        "projects/all/local-authorities",
+      ]
+    },
+    "exports" : {
+      order : 70,
+      require_cookie : false,
+      routes : [
+        "projects/all/export",
+        "projects/all/reports",
       ]
     }
   }
@@ -206,9 +256,24 @@ locals {
       order : 40,
       require_cookie : false,
       routes : [
-        "projects/all/in-progress/all",
+        "projects/all/in-progress",
       ]
-    }
+    },
+    "projects_pre_release" : {
+      order : 50,
+      require_cookie : true,
+      routes : [
+        "projects/team",
+        "projects/yours",
+        "projects/all/by-month",
+        "projects/all/completed",
+        "projects/all/local-authorities",
+        "projects/all/regions",
+        "projects/all/trusts",
+        "projects/all/users",
+        "projects/all/statistics",
+      ]
+    },
   }
 
   complete_dotnet_ruby_migration_all = {

--- a/locals.tf
+++ b/locals.tf
@@ -274,6 +274,14 @@ locals {
         "projects/all/statistics",
       ]
     },
+    "exports_pre_release" : {
+      order : 70,
+      require_cookie : true,
+      routes : [
+        "projects/all/export",
+        "projects/all/reports",
+      ]
+    }
   }
 
   complete_dotnet_ruby_migration_all = {


### PR DESCRIPTION
I've updated all 3 environments.

## Dev

- I've had to split projects into multiple lists because of the 10 rule per group restriction.
- Add statistics, exports and service support (local authorities/conversion URNs) to the rerouting

Exports includes the reports route. reports is a .net ONLY URL - there will be an internal redirection in the .net app from /exports to /reports. This difference is to be explained with comms to the end users

## Test

- same as with dev, only the service support redirections are feature flagged

The reason for feature flagging is that it's our first authenticated POST request that we'll be testing with the front door. Previously we tested cookies and had to bypass antiforgery, so this may come with some challenges

## Prod

- projects in progress will be live
- all listing pages will be feature flagged so that we can test them

Any project listing routes that we test successfully in prod can move from the `projects_pre_release` section to the `projects` section in a subsequent release.