### PR TITLE
Dotnet complete release 5 privacy groups handover ssla

### DIFF
--- a/.terraform.lock.hcl
+++ b/.terraform.lock.hcl
@@ -5,6 +5,7 @@ provider "registry.terraform.io/hashicorp/azuread" {
   version     = "2.53.1"
   constraints = "~> 2.37"
   hashes = [
+    "h1:/8F5vc1FReT/eVgZqS90PcaDnrKa4LZ1b9YWNkbTDsI=",
     "h1:EZNO8sEtUABuRxujQrDrW1z1QsG0dq6iLbzWtnG7Om4=",
     "zh:162916b037e5133f49298b0ffa3e7dcef7d76530a8ca738e7293373980f73c68",
     "zh:1c3e89cf19118fc07d7b04257251fc9897e722c16e0a0df7b07fcd261f8c12e7",
@@ -56,6 +57,7 @@ provider "registry.terraform.io/hashicorp/null" {
   constraints = "~> 3.2"
   hashes = [
     "h1:L5V05xwp/Gto1leRryuesxjMfgZwjb7oool4WS1UEFQ=",
+    "h1:VMNuSHZMkfsbrzvhpp6lzm2vWdmT/1vuUdW0x+Dsa0Q=",
     "zh:59f6b52ab4ff35739647f9509ee6d93d7c032985d9f8c6237d1f8a59471bbbe2",
     "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
     "zh:795c897119ff082133150121d39ff26cb5f89a730a2c8c26f3a9c1abf81a9c43",

--- a/docs/complete_fd_rules.md
+++ b/docs/complete_fd_rules.md
@@ -37,9 +37,9 @@ Current "operators" in use include:
 | /projects/all/export | Equal | ✅ | ✅ | ✅ |
 | /projects/all/reports | Equal | ✅ | ✅ | ✅ |
 | **/groups** | **Begins With** | 🆕✅ | 🆕⚠️ | 🆕⚠️ |
-| /projects/service-support/with-academy-urn/* | Begins With | ✅ | ⚠️ | ❌ |
-| /projects/service-support/without-academy-urn/* | Begins With | ✅ | ⚠️ | ❌ |
-| /service-support/local-authorities/* | Begins With | ✅ | ⚠️ | ❌ |
+| /projects/service-support/with-academy-urn/* | Begins With | ✅ | ⚠️ | ⚠️ |
+| /projects/service-support/without-academy-urn/* | Begins With | ✅ | ⚠️ | ⚠️ |
+| /service-support/local-authorities/* | Begins With | ✅ | ⚠️ | ⚠️ |
 | /search | RegEx | ✅ | ✅ | ✅ |
 | /cookies (GET) | Begins With | ✅ | ✅ | ✅ |
 | /cookies (POST) | Begins With | ✅ | ✅ | ✅ |
@@ -50,7 +50,7 @@ Current "operators" in use include:
 
 ## Version history:
 
-**5 - 2025-08-15** - add privacy notice, groups  
+**5 - 2025-08-15** - add privacy notice and groups routes, and add feature flag to service support (LAs and URNs) in production  
 **4 - 2025-08-07** - add access-denied route, which exists only on .NET. Otherwise, access denied pages present as "Page not found"  
 **3 - 2025-08-05**
 - release additional listing pages to production, excluding "Your projects" and "Team projects"

--- a/docs/complete_fd_rules.md
+++ b/docs/complete_fd_rules.md
@@ -37,9 +37,9 @@ Current "operators" in use include:
 | /projects/all/export | Equal | ✅ | ✅ | ✅ |
 | /projects/all/reports | Equal | ✅ | ✅ | ✅ |
 | **/groups** | **Begins With** | 🆕✅ | 🆕⚠️ | 🆕⚠️ |
-| /projects/service-support/with-academy-urn/* | Begins With | ✅ | ⚠️ | ⚠️ |
-| /projects/service-support/without-academy-urn/* | Begins With | ✅ | ⚠️ | ⚠️ |
-| /service-support/local-authorities/* | Begins With | ✅ | ⚠️ | ⚠️ |
+| /projects/service-support/with-academy-urn/* | Begins With | ✅ | ⚠️ | ❌ → ⚠️ |
+| /projects/service-support/without-academy-urn/* | Begins With | ✅ | ⚠️ | ❌ → ⚠️ |
+| /service-support/local-authorities/* | Begins With | ✅ | ⚠️ | ❌ → ⚠️ |
 | /search | RegEx | ✅ | ✅ | ✅ |
 | /cookies (GET) | Begins With | ✅ | ✅ | ✅ |
 | /cookies (POST) | Begins With | ✅ | ✅ | ✅ |

--- a/docs/complete_fd_rules.md
+++ b/docs/complete_fd_rules.md
@@ -10,7 +10,7 @@ Traffic is redirected to the [dotnet application](https://github.com/DFE-Digital
 ✅ - included. Hitting this route in ruby app will redirect through front door to dotnet for this environment  
 ❌ - not included. This page is routed fully by ruby and does not come through the front door  
 ⚠️ - feature flagged. Hitting this route in ruby with the session cookie `"dotnet-bypass"` (any value) will redirect through front door to dotnet. Otherwise, the route will be handled by ruby  
-❌ → ✅ - represents a rule change in the most recent update
+❌ → ✅ - represents a rule change in the most recent update  
 🆕 - route added. There are new rules in place for this route as of this release
 ## Operators
 
@@ -43,12 +43,14 @@ Current "operators" in use include:
 | /cookies (GET) | Begins With | ✅ | ✅ | ✅ |
 | /cookies (POST) | Begins With | ✅ | ✅ | ✅ |
 | /accessibility | Begins With | ✅ | ✅ | ✅ |
-| **/access-denied** | **Begins With** | 🆕 | 🆕 | 🆕 |
+| **/privacy** | **Begins With** | 🆕✅ | 🆕✅ | 🆕⚠️ |
+| /access-denied | Begins With | ✅ | ✅ | ✅ |
 
 
 ## Version history:
 
-**4 - 2025-08-07** - add access-denied route, which exists only on .NET. Otherwise, access denied pages present as "Page not found"
+**5 - 2025-08-15** - add privacy notice
+**4 - 2025-08-07** - add access-denied route, which exists only on .NET. Otherwise, access denied pages present as "Page not found"  
 **3 - 2025-08-05**
 - release additional listing pages to production, excluding "Your projects" and "Team projects"
 - release handover to dev and to test/prod with feature flag  

--- a/docs/complete_fd_rules.md
+++ b/docs/complete_fd_rules.md
@@ -36,6 +36,7 @@ Current "operators" in use include:
 | /projects/all/statistics/* | Begins With | ✅ | ✅ | ✅ |
 | /projects/all/export | Equal | ✅ | ✅ | ✅ |
 | /projects/all/reports | Equal | ✅ | ✅ | ✅ |
+| **/groups** | **Begins With** | 🆕✅ | 🆕⚠️ | 🆕⚠️ |
 | /projects/service-support/with-academy-urn/* | Begins With | ✅ | ⚠️ | ❌ |
 | /projects/service-support/without-academy-urn/* | Begins With | ✅ | ⚠️ | ❌ |
 | /service-support/local-authorities/* | Begins With | ✅ | ⚠️ | ❌ |
@@ -49,7 +50,7 @@ Current "operators" in use include:
 
 ## Version history:
 
-**5 - 2025-08-15** - add privacy notice
+**5 - 2025-08-15** - add privacy notice, groups  
 **4 - 2025-08-07** - add access-denied route, which exists only on .NET. Otherwise, access denied pages present as "Page not found"  
 **3 - 2025-08-05**
 - release additional listing pages to production, excluding "Your projects" and "Team projects"

--- a/locals.tf
+++ b/locals.tf
@@ -138,7 +138,14 @@ locals {
         "projects/all/reports",
       ],
       operator : "Equal"
-    }
+    },
+    "groups" : {
+      order : 90,
+      require_cookie : false,
+      routes : [
+        "groups",
+      ]
+    },
   }
   complete_dotnet_ruby_migration_paths_test = {
     "cookies" : {
@@ -226,6 +233,13 @@ locals {
         "projects/all/handover",
       ]
     },
+    "groupsprerelease" : {
+      order : 90,
+      require_cookie : true,
+      routes : [
+        "groups",
+      ]
+    },
   }
   complete_dotnet_ruby_migration_paths_production = {
     "cookies" : {
@@ -308,6 +322,13 @@ locals {
       require_cookie : true,
       routes : [
         "privacy",
+      ]
+    },
+    "groupsprerelease" : {
+      order : 90,
+      require_cookie : true,
+      routes : [
+        "groups",
       ]
     },
   }

--- a/locals.tf
+++ b/locals.tf
@@ -87,6 +87,7 @@ locals {
         "accessibility",
         "cookies",
         "access-denied",
+        "privacy",
       ]
     },
     "search" : {
@@ -167,6 +168,7 @@ locals {
         "accessibility",
         "cookies",
         "access-denied",
+        "privacy",
       ]
     },
     "search" : {
@@ -300,7 +302,14 @@ locals {
         "projects/all/reports",
       ],
       operator : "Equal"
-    }
+    },
+    "assetsprerelease" : {
+      order : 80,
+      require_cookie : true,
+      routes : [
+        "privacy",
+      ]
+    },
   }
 
   complete_dotnet_ruby_migration_all = {

--- a/locals.tf
+++ b/locals.tf
@@ -331,6 +331,15 @@ locals {
         "groups",
       ]
     },
+    "servicesupportprerelease" : {
+      order : 100,
+      require_cookie : true,
+      routes : [
+        "projects/service-support/with-academy-urn",
+        "projects/service-support/without-academy-urn",
+        "service-support/local-authorities",
+      ]
+    },
   }
 
   complete_dotnet_ruby_migration_all = {


### PR DESCRIPTION
Ahead of testing for releasing groups, handover, privacy notice and LAs/URNs in service support to production, I have made the following changes:
- groups - on for dev, feature flag for test/prod
- privacy notice - on for dev/test, feature flag for prod
- handover - no changes, already feature flagged
- service support sections - promoted to production with a feature flag

Here's the full changelog: https://github.com/DFE-Digital/rsd-frontdoor/blob/ecb5fd512c8aebe2ca7444c8e8faf31eae5ef4ca/docs/complete_fd_rules.md