### PR TITLE
add dotnet-disable flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ This project creates and manages the RSD FrontDoor CDN.
 | [azurerm_cdn_frontdoor_route.rsd](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/cdn_frontdoor_route) | resource |
 | [azurerm_cdn_frontdoor_rule.add_response_headers](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/cdn_frontdoor_rule) | resource |
 | [azurerm_cdn_frontdoor_rule.complete_dotnet_ruby_migration](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/cdn_frontdoor_rule) | resource |
+| [azurerm_cdn_frontdoor_rule.dotnet_disable_override](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/cdn_frontdoor_rule) | resource |
 | [azurerm_cdn_frontdoor_rule.host_redirects](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/cdn_frontdoor_rule) | resource |
 | [azurerm_cdn_frontdoor_rule.remove_response_headers](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/cdn_frontdoor_rule) | resource |
 | [azurerm_cdn_frontdoor_rule.security](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/cdn_frontdoor_rule) | resource |

--- a/docs/complete_fd_rules.md
+++ b/docs/complete_fd_rules.md
@@ -25,6 +25,12 @@ See a more definitive list of operators [here](https://learn.microsoft.com/en-us
 
 **NB**: The table only includes routes that have forwarding enabled for any environment. It is not an exhaustive list of routes that are available on either app.
 
+## Ruby fallback
+
+It is possible to ignore all of the rerouting rules in your local browser, which can be very useful for testing and debugging.
+
+By providing the request cookie `dotnet-disable`, all routes will revert to ruby rather than redirecting to .net.
+
 ## Routes  
 
 | Route | Operator | Dev | Test | Prod |  

--- a/rulesets.tf
+++ b/rulesets.tf
@@ -197,34 +197,26 @@ resource "azurerm_cdn_frontdoor_rule_set" "complete_dotnet_ruby_migration" {
   cdn_frontdoor_profile_id = azurerm_cdn_frontdoor_profile.rsd[0].id
 }
 
-resource "azurerm_cdn_frontdoor_rule" "ruby_bypass_override" {
-  count = local.enable_frontdoor ? 1 : 0
-
+resource "azurerm_cdn_frontdoor_rule" "dotnet_disable_override" {
   depends_on = [azurerm_cdn_frontdoor_origin_group.rsd, azurerm_cdn_frontdoor_origin.rsd]
 
-  name                      = "rubybypassoverride"
+  name                      = "dotnetdisableoverride"
   cdn_frontdoor_rule_set_id = azurerm_cdn_frontdoor_rule_set.complete_dotnet_ruby_migration[0].id
   order                     = 1
   behavior_on_match         = "Stop"
 
   conditions {
     cookies_condition {
-      cookie_name = "ruby-bypass"
+      cookie_name = "dotnet-disable"
       operator    = "Any"
     }
   }
 
   actions {
-    route_configuration_override_action {
-      cdn_frontdoor_origin_group_id = azurerm_cdn_frontdoor_origin_group.rsd["complete-ruby"].id
-      forwarding_protocol           = azurerm_cdn_frontdoor_route.rsd["complete-ruby"].forwarding_protocol
-      cache_behavior                = "Disabled"
-    }
-
     response_header_action {
       header_action = "Append"
       header_name   = "X-Backend-Origin-Rerouted"
-      value         = "ruby-bypass"
+      value         = "ruby"
     }
   }
 }


### PR DESCRIPTION
Add the option for a dotnet-disable cookie so that we can disable all rules for a given environment on our local browsers.

This has been necessary for debugging several times but not possible