### PR TITLE
Dotnet complete release 9 phase one

### DIFF
--- a/docs/complete_fd_rules.md
+++ b/docs/complete_fd_rules.md
@@ -36,9 +36,9 @@ By providing the request cookie `dotnet-disable`, all routes will revert to ruby
 | Route | Operator | Dev | Test | Prod |  
 | - | - | - | - | - |
 | /projects/*/academy-urn | RegEx | ✅ | ✅ | ✅ |
-| **/projects/*/internal-contacts/\*** | **RegEx** | 🆕✅ | 🆕⚠️ | 🆕⚠️ |
-| **/projects/*/tasks** | **RegEx** | 🆕✅ | 🆕⚠️ | 🆕⚠️ |
-| **/projects/*/notes/\*** | **RegEx** | 🆕✅ | 🆕⚠️ | 🆕⚠️ |
+| /projects/*/internal-contacts/\* | RegEx | ✅ | ⚠️ | ⚠️ |
+| /projects/*/tasks | RegEx | ✅ | ⚠️ | ⚠️ |
+| /projects/\*/notes/\* | RegEx | ✅ | ⚠️ | ⚠️ |
 | /projects/team/* | Begins With | ✅ | ✅ | ✅ |
 | /projects/yours/* | Begins With | ✅ | ✅ | ✅ |
 | /projects/all/handover/* | Begins With | ✅ | ✅ | ✅ |
@@ -57,7 +57,7 @@ By providing the request cookie `dotnet-disable`, all routes will revert to ruby
 | /projects/service-support/without-academy-urn/* | Begins With | ✅ |  ✅ | ✅ |
 | /service-support/local-authorities/* | Begins With | ✅ | ✅ | ✅ |
 | /search | RegEx | ✅ | ✅ | ✅ |
-| **/search/user** | **RegEx** | 🆕✅ | 🆕⚠️ | 🆕⚠️ |
+| /search/user | RegEx | ✅ | ⚠️ | ⚠️ |
 | /cookies (GET) | Begins With | ✅ | ✅ | ✅ |
 | /cookies (POST) | Begins With | ✅ | ✅ | ✅ |
 | /accessibility | Begins With | ✅ | ✅ | ✅ |

--- a/docs/complete_fd_rules.md
+++ b/docs/complete_fd_rules.md
@@ -31,6 +31,26 @@ It is possible to ignore all of the rerouting rules in your local browser, which
 
 By providing the request cookie `dotnet-disable`, all routes will revert to ruby rather than redirecting to .net.
 
+## Task identifiers
+
+We are releasing various tasks through the front door - a list of tasks which will progressively get longer.
+
+For brevity, I've just referenced these tasks as {task_identifiers} in the Routes table (see below).
+
+The full "route" looks something like this: **/projects/\*/tasks/{task_identifiers}** - where {task_identifiers} matches one of the promoted tasks.
+
+At present, these tasks are:
+- handover
+- stakeholder_kick_off
+- proposed_capacity_of_the_academy
+- supplemental_funding_agreement
+- articles_of_association
+- deed_of_variation
+- conditions_met
+- redact_and_send
+- receive_grant_payment_certificate
+- deed_of_novation_and_variation
+
 ## Routes  
 
 | Route | Operator | Dev | Test | Prod |  
@@ -39,6 +59,7 @@ By providing the request cookie `dotnet-disable`, all routes will revert to ruby
 | /projects/*/internal-contacts/\* | RegEx | ✅ | ⚠️ | ⚠️ |
 | /projects/*/tasks | RegEx | ✅ | ⚠️ | ⚠️ |
 | /projects/\*/notes/\* | RegEx | ✅ | ⚠️ → ❌ | ⚠️ → ❌  |
+| **/projects/\*/tasks/{task_identifiers}** | **Regex** | 🆕✅ | 🆕⚠️ | 🆕⚠️ |
 | /projects/team/* | Begins With | ✅ | ✅ | ✅ |
 | /projects/yours/* | Begins With | ✅ | ✅ | ✅ |
 | /projects/all/handover/* | Begins With | ✅ | ✅ | ✅ |
@@ -69,6 +90,7 @@ By providing the request cookie `dotnet-disable`, all routes will revert to ruby
 
 **9 - 2025-10-02**
 - remove notes feature flag from test and prod to allow for "clean" testing. Notes will need releasing after all tasks due to TmpData buglets  
+- add various tasks routes (10 in total) using a regex pattern
 
 **8 - 2025-08-28**
 - add notes, internal contacts and task list to dev, feature flagged in test/prod

--- a/docs/complete_fd_rules.md
+++ b/docs/complete_fd_rules.md
@@ -38,7 +38,7 @@ By providing the request cookie `dotnet-disable`, all routes will revert to ruby
 | /projects/*/academy-urn | RegEx | ✅ | ✅ | ✅ |
 | /projects/*/internal-contacts/\* | RegEx | ✅ | ⚠️ | ⚠️ |
 | /projects/*/tasks | RegEx | ✅ | ⚠️ | ⚠️ |
-| /projects/\*/notes/\* | RegEx | ✅ | ⚠️ | ⚠️ |
+| /projects/\*/notes/\* | RegEx | ✅ | ⚠️ → ❌ | ⚠️ → ❌  |
 | /projects/team/* | Begins With | ✅ | ✅ | ✅ |
 | /projects/yours/* | Begins With | ✅ | ✅ | ✅ |
 | /projects/all/handover/* | Begins With | ✅ | ✅ | ✅ |
@@ -66,6 +66,9 @@ By providing the request cookie `dotnet-disable`, all routes will revert to ruby
 
 
 ## Version history:
+
+**9 - 2025-10-02**
+- remove notes feature flag from test and prod to allow for "clean" testing. Notes will need releasing after all tasks due to TmpData buglets  
 
 **8 - 2025-08-28**
 - add notes, internal contacts and task list to dev, feature flagged in test/prod

--- a/docs/complete_fd_rules.md
+++ b/docs/complete_fd_rules.md
@@ -48,7 +48,9 @@ At present, these tasks are:
 - deed_of_variation
 - conditions_met
 - redact_and_send
+- redact_and_send_documents
 - receive_grant_payment_certificate
+- declaration_of_expenditure_certificate
 - deed_of_novation_and_variation
 
 ## Routes  

--- a/docs/complete_fd_rules.md
+++ b/docs/complete_fd_rules.md
@@ -59,6 +59,7 @@ At present, these tasks are:
 | /projects/*/internal-contacts/\* | RegEx | ✅ | ⚠️ | ⚠️ |
 | /projects/*/tasks | RegEx | ✅ | ⚠️ | ⚠️ |
 | /projects/\*/notes/\* | RegEx | ✅ | ⚠️ → ❌ | ⚠️ → ❌  |
+| **/projects/\*/date_history/\*** | **Regex** | 🆕✅ | 🆕⚠️ | 🆕⚠️ |
 | **/projects/\*/tasks/{task_identifiers}** | **Regex** | 🆕✅ | 🆕⚠️ | 🆕⚠️ |
 | /projects/team/* | Begins With | ✅ | ✅ | ✅ |
 | /projects/yours/* | Begins With | ✅ | ✅ | ✅ |
@@ -90,7 +91,8 @@ At present, these tasks are:
 
 **9 - 2025-10-02**
 - remove notes feature flag from test and prod to allow for "clean" testing. Notes will need releasing after all tasks due to TmpData buglets  
-- add various tasks routes (10 in total) using a regex pattern
+- add various tasks routes (10 in total) using a regex pattern  
+- add date history using the same regex as project notes, internal contacts  
 
 **8 - 2025-08-28**
 - add notes, internal contacts and task list to dev, feature flagged in test/prod

--- a/locals.tf
+++ b/locals.tf
@@ -264,7 +264,7 @@ locals {
       order : 100,
       require_cookie : true,
       routes : [
-        "${local.complete_dotnet_project_prefix}/(?:(?:internal-contacts|notes)(?:/.*)?|tasks)$",
+        "${local.complete_dotnet_project_prefix}/(?:(?:internal-contacts)(?:/.*)?|tasks)$",
       ],
       operator : "RegEx",
     },
@@ -376,7 +376,7 @@ locals {
       order : 100,
       require_cookie : true,
       routes : [
-        "${local.complete_dotnet_project_prefix}/(?:(?:internal-contacts|notes)(?:/.*)?|tasks)$",
+        "${local.complete_dotnet_project_prefix}/(?:(?:internal-contacts)(?:/.*)?|tasks)$",
       ],
       operator : "RegEx",
     },

--- a/locals.tf
+++ b/locals.tf
@@ -58,8 +58,9 @@ locals {
   waf_rate_limiting_bypass_ip_list      = var.waf_rate_limiting_bypass_ip_list
 
 
-  enable_custom_reroute_ruleset    = var.enable_custom_reroute_ruleset
-  complete_dotnet_project_prefix   = "^projects/[^/]+"
+  enable_custom_reroute_ruleset  = var.enable_custom_reroute_ruleset
+  complete_dotnet_project_prefix = "^projects/[^/]+"
+
   complete_dotnet_task_identifiers = [
     "handover",
     "stakeholder_kick_off",

--- a/locals.tf
+++ b/locals.tf
@@ -172,7 +172,7 @@ locals {
       order : 100,
       require_cookie : false,
       routes : [
-        "${local.complete_dotnet_project_prefix}/(?:(?:internal-contacts|notes)(?:/.*)?|tasks)$",
+        "${local.complete_dotnet_project_prefix}/(?:(?:internal-contacts|notes|date-history)(?:/.*)?|tasks)$",
       ],
       operator : "RegEx",
     },
@@ -284,7 +284,7 @@ locals {
       order : 100,
       require_cookie : true,
       routes : [
-        "${local.complete_dotnet_project_prefix}/(?:(?:internal-contacts)(?:/.*)?|tasks)$",
+        "${local.complete_dotnet_project_prefix}/(?:(?:internal-contacts|date-history)(?:/.*)?|tasks)$",
       ],
       operator : "RegEx",
     },
@@ -404,7 +404,7 @@ locals {
       order : 100,
       require_cookie : true,
       routes : [
-        "${local.complete_dotnet_project_prefix}/(?:(?:internal-contacts)(?:/.*)?|tasks)$",
+        "${local.complete_dotnet_project_prefix}/(?:(?:internal-contacts|date-history)(?:/.*)?|tasks)$",
       ],
       operator : "RegEx",
     },

--- a/locals.tf
+++ b/locals.tf
@@ -58,8 +58,20 @@ locals {
   waf_rate_limiting_bypass_ip_list      = var.waf_rate_limiting_bypass_ip_list
 
 
-  enable_custom_reroute_ruleset  = var.enable_custom_reroute_ruleset
-  complete_dotnet_project_prefix = "^projects/[^/]+"
+  enable_custom_reroute_ruleset    = var.enable_custom_reroute_ruleset
+  complete_dotnet_project_prefix   = "^projects/[^/]+"
+  complete_dotnet_task_identifiers = [
+    "handover",
+    "stakeholder_kick_off",
+    "proposed_capacity_of_the_academy",
+    "supplemental_funding_agreement",
+    "articles_of_association",
+    "deed_of_variation",
+    "conditions_met",
+    "redact_and_send",
+    "receive_grant_payment_certificate",
+    "deed_of_novation_and_variation"
+  ]
 
   complete_dotnet_ruby_migration_paths_development = {
     "cookies" : {
@@ -161,6 +173,14 @@ locals {
       require_cookie : false,
       routes : [
         "${local.complete_dotnet_project_prefix}/(?:(?:internal-contacts|notes)(?:/.*)?|tasks)$",
+      ],
+      operator : "RegEx",
+    },
+    "projecttasks" : {
+      order : 110,
+      require_cookie : false,
+      routes : [
+        "${local.complete_dotnet_project_prefix}/tasks/(?:${join("|", local.complete_dotnet_task_identifiers)})$",
       ],
       operator : "RegEx",
     },
@@ -276,6 +296,14 @@ locals {
       ],
       operator : "RegEx"
     },
+    "projecttasksprerelease" : {
+      order : 120,
+      require_cookie : true,
+      routes : [
+        "${local.complete_dotnet_project_prefix}/tasks/(?:${join("|", local.complete_dotnet_task_identifiers)})$",
+      ],
+      operator : "RegEx",
+    },
   }
   complete_dotnet_ruby_migration_paths_production = {
     "cookies" : {
@@ -387,6 +415,14 @@ locals {
         "^search/user(?:\\?(?:[^\\/#]*))?$",
       ],
       operator : "RegEx"
+    },
+    "projecttasksprerelease" : {
+      order : 120,
+      require_cookie : true,
+      routes : [
+        "${local.complete_dotnet_project_prefix}/tasks/(?:${join("|", local.complete_dotnet_task_identifiers)})$",
+      ],
+      operator : "RegEx",
     },
   }
 

--- a/locals.tf
+++ b/locals.tf
@@ -69,7 +69,9 @@ locals {
     "deed_of_variation",
     "conditions_met",
     "redact_and_send",
+    "redact_and_send_documents",
     "receive_grant_payment_certificate",
+    "declaration_of_expenditure_certificate",
     "deed_of_novation_and_variation"
   ]
 


### PR DESCRIPTION
## Description

Disable notes (feature flagged) in test/prod. Even feature flagged, this has the potential to impact our testing. It's a low impact bug that we're seeing but a clean test environment would be best. Bug: TmpData doesn't clear when next request is ruby site but it does get consumed on the next .net render, resulting in banner updates appearing potentially much later

Internal contacts and tasks page are already in the correct state but will be in this next release, so calling it out here.

Added date history to the pre-prod state (live in dev, feature flagged in test/prod).

Added 10 tasks to the pre-prod state (live in dev, feature flagged in test/prod).